### PR TITLE
Hostが退出時にルームが削除されるように実装

### DIFF
--- a/server/mock/db.json
+++ b/server/mock/db.json
@@ -140,37 +140,27 @@
       "gameState": "waiting",
       "createdAt": "2025-07-06T08:05:51.418401853Z"
     },
-    "can": {
-      "roomId": "can",
-      "hostId": "user_5df367d5f4fa6514",
+    "fuck": {
+      "roomId": "fuck",
+      "hostId": "user_85cf985b50d85fcb",
       "settings": {
         "difficulty": "Normal",
         "language": "Go"
       },
       "players": {
-        "user_378defa27fb75d8b": {
-          "name": "3",
-          "score": 0,
-          "isReady": false
-        },
-        "user_4b913219e26559ba": {
-          "name": "4",
-          "score": 0,
-          "isReady": false
-        },
-        "user_5a0c978988de7174": {
-          "name": "2",
-          "score": 0,
-          "isReady": false
-        },
-        "user_5df367d5f4fa6514": {
+        "user_85cf985b50d85fcb": {
           "name": "Host",
           "score": 0,
           "isReady": true
+        },
+        "user_9926f7609cb2d2ac": {
+          "name": "2",
+          "score": 0,
+          "isReady": false
         }
       },
       "gameState": "waiting",
-      "createdAt": "2025-07-12T11:04:40.655219322Z"
+      "createdAt": "2025-07-12T12:25:28.541689714Z"
     },
     "gast": {
       "roomId": "gast",

--- a/server/src/cmd/route/main.go
+++ b/server/src/cmd/route/main.go
@@ -16,13 +16,13 @@ import (
 
 func main() {
 	cfg := config.Load()
-	
+
 	db, err := database.NewDBHandler(cfg.DBPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize database: %v", err)
 	}
 	// WebSocket Hubを生成
-	hub := websocket.NewRoomHub()
+	hub := websocket.NewRoomHub(db)
 
 	// QuizServiceを生成
 	quizSvc := service.NewQuizService(hub)
@@ -40,6 +40,10 @@ func main() {
 	e.Use(middleware.CORS())
 
 	api := e.Group("/api")
+
+    api.GET("/", func(c echo.Context) error {
+        return c.String(200, "OK")
+    })
 	room.RegisterRoutes(api.Group("/room"), db)
 	// quiz.RegisterRoutes に quizSvc を渡す
 	quiz.RegisterRoutes(api.Group("/quiz"), hub, quizSvc)


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか
ホストがルームを退出(websocket通信が切断)したときに部屋が削除されるようになった
<!-- 変更内容を簡潔に説明してください -->

### なぜ変更したか
同じ部屋名が二度目使えなくなってしまう、データベースにゴミデータがたまりまくる
<!-- 変更の理由や背景を説明してください -->

---

## 🧪 テスト・確認項目
作成したルームが削除されることを確認、ただしルーム作成時ホストの名前がHost固定のためクライアント側でwebsocketにつなげる際にホストのプレイヤー名はHostにしないとうまく機能しない
### 動作確認
<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 📸 スクリーンショット（UI変更がある場合）
<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before | After |
| ------ | ----- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項
<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連Issue
<!-- 関連するIssueがあれば記載してください -->
Closes #