### PR TITLE
【ドキュメント】開発者向けのドキュメント作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Environment variables
+.env
+.env.local
+.env.*.local
+.env.prod
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Temporary files
+tmp/
+temp/
+*.tmp

--- a/client/README.md
+++ b/client/README.md
@@ -1,36 +1,33 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Client
 
-## Getting Started
+Next.jsで実装されたフロントエンド。
 
-First, run the development server:
+## 技術スタック
+
+- Next.js 15 (App Router)
+- React 19
+- TypeScript
+- Tailwind CSS
+
+## 開発環境のセットアップ
+
+### 必要な環境
+
+- Node.js 20以上
+- pnpm 10以上
+
+### 環境変数の設定
+
+`.env.local`ファイルを作成して必要な環境変数を設定してください。
+
+### 依存関係のインストール
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm i --frozen-lockfile
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### 開発サーバーの起動
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+pnpm dev
+```

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,42 @@
+# Server
+
+Goで実装されたバックエンドサーバー
+
+## ディレクトリ構成
+
+```
+server/
+├── src/          # メインのGoプロジェクト
+└── mock/         # モックデータ
+```
+
+## 開発環境のセットアップ
+
+### 必要な環境
+
+- Go 1.24.4以上
+
+### 環境変数の設定
+
+`src/config/.env.local.example`をコピーして`.env.local`を作成：
+
+```bash
+cd src/config
+cp .env.local.example .env.local
+```
+
+### サーバーの起動
+
+#### 開発モード（ホットリロード）
+
+```bash
+cd src
+air -c config/.air.toml
+```
+
+#### 通常起動
+
+```bash
+cd src
+go run cmd/route/main.go
+```


### PR DESCRIPTION
## やったこと
- .gitignoreをルートに追加
-フロントとバックで、セットアップのドキュメント作成
  - サーバーの立ち上げ方とか

## なぜやったか
- 久しぶりに作業する時に、サーバーの立ち上げ方忘れちゃうため

## メモ
README.md 意外に、適したドキュメントあったかな？
CONTRIBUTING.md とかあるけれど、これは本当に外部の人向けのドキュメントって印象あるから適してるのかな？って

ルートにREADME置く場合は、それは「このプロジェクトはこういうサービス」って紹介向けのREADMEにしたいんよね。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds root .gitignore and replaces client/server READMEs with concise setup guides and tech stack details.
> 
> - **Documentation**:
>   - **`client/README.md`**: Replace boilerplate with Japanese setup guide (tech stack, prerequisites, env vars, install, dev server).
>   - **`server/README.md`**: Add Go backend docs with directory structure, env setup, and run instructions (including `air` hot-reload and `go run`).
> - **Repository**:
>   - **`.gitignore`**: Add root ignore rules for env files, OS files, logs, and temp artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9fafea0c603b277325aebbbfd32765c229b1f81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->